### PR TITLE
Switch to using python standard library importlib

### DIFF
--- a/gargoyle/__init__.py
+++ b/gargoyle/__init__.py
@@ -24,7 +24,12 @@ def autodiscover():
     """
     import copy
     from django.conf import settings
-    from django.utils.importlib import import_module
+    
+    try:
+        from importlib import import_module
+    except:
+        # removed in django 1.9, only included for backwards compatibility
+        from django.utils.importlib import import_module
 
     for app in settings.INSTALLED_APPS:
         # Attempt to import the app's gargoyle module.


### PR DESCRIPTION
  https://docs.djangoproject.com/en/1.9/internals/deprecation/#deprecation-removed-in-1-9
  django.utils.importlib is removed in django 1.9

  This code now tries to import the stdlib first (available only in python 2.7+, if it fails fall back to the django.utils.importlib