### PR TITLE
Remove all compatibility code for Django < 1.7 / Python < 2.7

### DIFF
--- a/gargoyle/builtins.py
+++ b/gargoyle/builtins.py
@@ -9,6 +9,7 @@ import socket
 import struct
 
 from django.conf import settings
+from django.contrib.auth import get_user_model
 from django.contrib.auth.models import AnonymousUser
 from django.core.validators import validate_ipv4_address
 
@@ -17,12 +18,7 @@ from gargoyle.conditions import (
     Boolean, ConditionSet, ModelConditionSet, OnOrAfterDate, Percent, RequestConditionSet, String
 )
 
-try:
-    from django.contrib.auth import get_user_model
-except ImportError:  # django < 1.5
-    from django.contrib.auth.models import User
-else:
-    User = get_user_model()
+User = get_user_model()
 
 
 class UserConditionSet(ModelConditionSet):

--- a/gargoyle/conditions.py
+++ b/gargoyle/conditions.py
@@ -5,7 +5,6 @@ gargoyle.conditions
 :copyright: (c) 2010 DISQUS.
 :license: Apache License 2.0, see LICENSE for more details.
 """
-
 # TODO: i18n
 # Credit to Haystack for abstraction concepts
 

--- a/gargoyle/models.py
+++ b/gargoyle/models.py
@@ -5,18 +5,11 @@ gargoyle.models
 :copyright: (c) 2010 DISQUS.
 :license: Apache License 2.0, see LICENSE for more details.
 """
-
 from django.conf import settings
 from django.db import models
+from django.utils.timezone import now
 from django.utils.translation import ugettext_lazy as _
 from jsonfield import JSONField
-
-try:
-    from django.utils.timezone import now
-except ImportError:
-    import datetime
-    now = datetime.datetime.now
-
 
 DISABLED = 1
 SELECTIVE = 2

--- a/gargoyle/nexus_modules.py
+++ b/gargoyle/nexus_modules.py
@@ -5,7 +5,6 @@ gargoyle.nexus_modules
 :copyright: (c) 2010 DISQUS.
 :license: Apache License 2.0, see LICENSE for more details.
 """
-
 import logging
 import os.path
 from functools import wraps

--- a/gargoyle/templates/gargoyle/index.html
+++ b/gargoyle/templates/gargoyle/index.html
@@ -127,7 +127,7 @@
         </tr>
         {% endfor %}
     </table>
-    {% raw %}
+    {% verbatim %}
         <script type="text/x-jquery-tmpl" id="switchForm">
             {{ if add }}
             <h2>Add a Switch</h2>
@@ -232,7 +232,7 @@
                 </td>
             </tr>
         </script>
-    {% endraw %}
+    {% endverbatim %}
 
     <script type="text/x-jquery-tmpl" id="switchConditions">
         <div class="clearfix">

--- a/gargoyle/templatetags/gargoyle_helpers.py
+++ b/gargoyle/templatetags/gargoyle_helpers.py
@@ -5,46 +5,17 @@ gargoyle.templatetags.gargoyle_helpers
 :copyright: (c) 2010 DISQUS.
 :license: Apache License 2.0, see LICENSE for more details.
 """
+from django import template
 
-try:
-    from django.template import base as template_base
-except ImportError:
-    from django import template as template_base
-
-register = template_base.Library()
+register = template.Library()
 
 
-def raw(parser, token):
-    # Whatever is between {% raw %} and {% endraw %} will be preserved as
-    # raw, unrendered template code.
-    text = []
-    parse_until = 'endraw'
-    tag_mapping = {
-        template_base.TOKEN_TEXT: ('', ''),
-        template_base.TOKEN_VAR: ('{{', '}}'),
-        template_base.TOKEN_BLOCK: ('{%', '%}'),
-        template_base.TOKEN_COMMENT: ('{#', '#}'),
-    }
-    # By the time this template tag is called, the template system has already
-    # lexed the template into tokens. Here, we loop over the tokens until
-    # {% endraw %} and parse them to TextNodes. We have to add the start and
-    # end bits (e.g. "{{" for variables) because those have already been
-    # stripped off in a previous part of the template-parsing process.
-    while parser.tokens:
-        token = parser.next_token()
-        if token.token_type == template_base.TOKEN_BLOCK and token.contents == parse_until:
-            return template_base.TextNode(u''.join(text))
-        start, end = tag_mapping[token.token_type]
-        text.append(u'%s%s%s' % (start, token.contents, end))
-    parser.unclosed_block_tag(parse_until)
-raw = register.tag(raw)
-
-
+@register.filter
 def render_field(field, value=None):
     return field.render(value)
-render_field = register.filter(render_field)
 
 
+@register.filter
 def sort_by_key(field, currently):
     is_negative = currently.find('-') is 0
     current_field = currently.lstrip('-')
@@ -56,10 +27,7 @@ def sort_by_key(field, currently):
     else:
         return field
 
-sort_by_key = register.filter(sort_by_key)
 
-
+@register.filter
 def sort_field(sort_string):
     return sort_string.lstrip('-')
-
-sort_field = register.filter(sort_field)

--- a/gargoyle/templatetags/gargoyle_tags.py
+++ b/gargoyle/templatetags/gargoyle_tags.py
@@ -5,7 +5,6 @@ gargoyle.templatetags.gargoyle_tags
 :copyright: (c) 2010 DISQUS.
 :license: Apache License 2.0, see LICENSE for more details.
 """
-
 from django import template
 
 from gargoyle import gargoyle

--- a/gargoyle/testutils.py
+++ b/gargoyle/testutils.py
@@ -5,7 +5,6 @@ gargoyle.testutils
 :copyright: (c) 2010 DISQUS.
 :license: Apache License 2.0, see LICENSE for more details.
 """
-
 from functools import wraps
 
 from gargoyle import gargoyle


### PR DESCRIPTION
Since we only support Django 1.7+ and Python 2.7+ now, we can tidy this all up.