### PR TITLE
Use the YPlan fork of django-modeldict

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,6 +8,7 @@ Pending Release
 ---------------
 
 * Support for Django 1.9
+* Use the YPlan fork of ``django-modeldict``
 
 1.0.1 (2015-12-09)
 ------------------

--- a/README.rst
+++ b/README.rst
@@ -29,7 +29,13 @@ Install it with ``pip`` (or ``easy_install``):
 
     pip install gargoyle-yplan
 
-Make sure you ``pip uninstall gargoyle`` first if you're upgrading from the original to this fork - the packages clash.
+If you are upgrading from the original to this fork, you will need to run the following first, since the packages clash:
+
+.. code-block:: bash
+
+    pip uninstall django-modeldict gargoyle
+
+Failing to do this will mean that `pip uninstall gargoyle` will also erase the files for `gargoyle-yplan`, and similarly for our `django-modeldict` fork.
 
 Documentation
 -------------

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     packages=find_packages(exclude=["example_project", "tests"]),
     zip_safe=False,
     install_requires=[
-        'django-modeldict>=1.2.0',
+        'django-modeldict-yplan>=1.5.0',
         'nexus-yplan>=1.0.0',
         'django-jsonfield>=0.9.2,!=0.9.13',
     ],


### PR DESCRIPTION
Done so we can add Django 1.9 and Python 3 compatibility.