### PR TITLE
Remove support for Django 1.7

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -9,6 +9,7 @@ Pending Release
 
 * Support for Django 1.9
 * Use the YPlan fork of ``django-modeldict``
+* Removed support for Django 1.7
 
 1.0.1 (2015-12-09)
 ------------------

--- a/README.rst
+++ b/README.rst
@@ -18,7 +18,7 @@ Requirements
 Tested with all combinations of:
 
 * Python: 2.7
-* Django: 1.7, 1.8, 1.9
+* Django: 1.8, 1.9
 
 Install
 -------

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -1,8 +1,6 @@
 # -*- coding:utf-8 -*-
 import os
 
-import django
-
 BASE_DIR = os.path.dirname(os.path.dirname(__file__))
 
 DEBUG = True
@@ -35,8 +33,6 @@ INSTALLED_APPS = (
     'gargoyle',
     'testapp'
 )
-if django.VERSION[:2] < (1, 7):
-    INSTALLED_APPS += ('south',)
 
 MIDDLEWARE_CLASSES = (
     'django.middleware.common.CommonMiddleware',

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist =
     py27-codestyle,
-    py27-nexus10-django{17,18},
-    py27-nexusmaster-django{17,18,19}
+    py27-nexus10-django18,
+    py27-nexusmaster-django{18,19}
 
 [testenv]
 setenv =
@@ -11,7 +11,6 @@ install_command = pip install --no-deps {opts} {packages}
 deps =
     nexus10: nexus-yplan>=1.0,<1.1
     nexusmaster: https://github.com/YPlan/nexus/archive/master.tar.gz
-    django17: Django>=1.7,<1.8
     django18: Django>=1.8,<1.9
     django19: Django>=1.9,<1.10
     -rrequirements.txt


### PR DESCRIPTION
It's no longer supported by Django, so we don't need to either.