### PR TITLE
Require nexus-yplan >= 1.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
     zip_safe=False,
     install_requires=[
         'django-modeldict-yplan>=1.5.0',
-        'nexus-yplan>=1.0.0',
+        'nexus-yplan>=1.1.0',
         'django-jsonfield>=0.9.2,!=0.9.13',
     ],
     license='Apache License 2.0',

--- a/tox.ini
+++ b/tox.ini
@@ -1,16 +1,13 @@
 [tox]
 envlist =
     py{27,35}-codestyle,
-    py27-nexus10-django18,
-    py{27,34,35}-nexusmaster-django{18,19}
+    py{27,34,35}-django{18,19}
 
 [testenv]
 setenv =
     PYTHONDONTWRITEBYTECODE=1
 install_command = pip install {opts} {packages}
 deps =
-    nexus10: nexus-yplan>=1.0,<1.1
-    nexusmaster: https://github.com/YPlan/nexus/archive/master.tar.gz
     django18: Django>=1.8,<1.9
     django19: Django>=1.9,<1.10
     -rrequirements.txt


### PR DESCRIPTION
This is the version that supports Python 3, and now we support Python 3, we require it.