### PR TITLE
Tidy requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,7 @@
 docutils
 flake8
 isort
-py==1.4.31
 Pygments
-pytest-django
 pytest
+pytest-django
 sqlparse


### PR DESCRIPTION
Unfix `py`, it should be installed as a dependency of `pytest`.