### PR TITLE
Fix jQuery templates

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,9 +8,12 @@ Pending Release
 ---------------
 
 * New release notes here
+* Fix jQuery Templates
 
 1.1.0 (2016-01-14)
 ------------------
+
+*This version has a broken UI, please upgrade*
 
 * Support for Django 1.9
 * Use the YPlan fork of ``django-modeldict``

--- a/gargoyle/templates/gargoyle/index.html
+++ b/gargoyle/templates/gargoyle/index.html
@@ -128,17 +128,17 @@
     </table>
     {% verbatim %}
         <script type="text/x-jquery-tmpl" id="switchForm">
-            {{ if add }}
+            {{if add}}
             <h2>Add a Switch</h2>
-            {{ else }}
+            {{else}}
             <h2>Update a Switch</h2>
-            {{ /if }}
+            {{/if}}
 
             <table class="switchForm">
                 <tr>
                     <th>Name:</th>
                     <td>
-                        <input name="name" type="text" value="{{ if name }}${name}{{ /if }}">
+                        <input name="name" type="text" value="{{if name}}${name}{{/if}}">
                         <p>A descriptive name for this switch.</p>
                     </td>
                 </tr>
@@ -146,7 +146,7 @@
                 <tr>
                     <th>Key:</th>
                     <td>
-                        <input name="key" type="text" value="{{ if key }}${key}{{ /if }}">
+                        <input name="key" type="text" value="{{if key}}${key}{{/if}}">
                         <p>The key can be any valid JSON string.</p>
                     </td>
                 </tr>
@@ -154,7 +154,7 @@
                 <tr>
                     <th>Description:</th>
                     <td>
-                        <textarea name="desc">{{ if desc }}${desc}{{ /if }}</textarea>
+                        <textarea name="desc">{{if desc}}${desc}{{/if}}</textarea>
                         <p>A brief description on what this switch accomplishes.</p>
                     </td>
                 </tr>
@@ -162,9 +162,9 @@
                 <tr>
                     <td colspan="2" class="buttons">
                         <button
-                            data-action="{{ if add }}add{{ else }}update{{ /if }}"
+                            data-action="{{if add}}add{{else}}update{{/if}}"
                             data-curkey="${curkey}"
-                            class="submitSwitch small button">{{ if add }}Add{{ else }}Update{{ /if }}</button>
+                            class="submitSwitch small button">{{if add}}Add{{else}}Update{{/if}}</button>
                         or <a href="#" class="closeFacebox">cancel</a>
                     </td>
                 </tr>
@@ -181,10 +181,10 @@
                         {{/if}}
 
                         <div class="conditions">
-                            {{ each(i, group) conditions }}
+                            {{each(i, group) conditions}}
                                 <div class="group">
                                     <label>${group.label}</label>
-                                    {{ each(i, item) group.conditions }}
+                                    {{each(i, item) group.conditions}}
                                         <span data-switch="${group.id}" data-field="${item[0]}" data-value="${item[1]}" class="value">
                                             <nobr>{{if item[3]}}<strong>not</strong> {{/if}}${item[2]}
                                               <a href="#" class="delete-condition" title="Delete this condition">
@@ -192,9 +192,9 @@
                                               </a>
                                             </nobr>
                                         </span>
-                                    {{ /each }}
+                                    {{/each}}
                                 </div>
-                            {{ /each }}
+                            {{/each}}
                         </div>
 
                         <p class="addCondition"><a href="#">Add a condition</a></p>


### PR DESCRIPTION
These were broken in 73f82a3a0ed6ca09f363efd3a2f727e4114a3edb with the move from `{% raw %}` to `{% verbatim %}`. The key oversight was that `raw`'s implementation would convert `{{ x }}` into `{{x}}` since it was implemented post-parse and reconstructed the braces - and the `jQuery.tmpl` plugin would only work with no spaces.

Tested by replacing this file in our local app, it worked. Next time javascript-affecting changes will be tested more thoroughly.