### PR TITLE
Wrap id's of selectors in quotes

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -11,6 +11,8 @@ Pending Release
 * Fixed the splitting of ``Range`` conditions, a merge of disqus/gargoyle#55,
   thanks @matclayton.
 * Fixed the parsing of ``Range`` conditions for the Nexus admin interface.
+* Fixed the Nexus interface to work with Switches that contain dots in their
+  names, a merge of disqus/gargoyle#73, thanks @Raekkeri.
 
 1.1.1 (2016-01-15)
 ------------------

--- a/gargoyle/media/js/gargoyle.js
+++ b/gargoyle/media/js/gargoyle.js
@@ -129,7 +129,7 @@ $(document).ready(function () {
 
         $(this).
             parents("tr:first").
-            find("div[data-path=" + field[0] + "." + field[1] + "]").show();
+            find("div[data-path='" + field[0] + "." + field[1] + "']").show();
     });
 
     $("div.conditionsForm form").live("submit", function (ev) {
@@ -154,7 +154,7 @@ $(document).ready(function () {
 
         api(GARGOYLE.addCondition, data, function (swtch) {
             var result = $("#switchData").tmpl(swtch);
-            $("table.switches tr[data-switch-key="+ data.key + "]").replaceWith(result);
+            $("table.switches tr[data-switch-key='"+ data.key + "']").replaceWith(result);
         });
     });
 
@@ -172,7 +172,7 @@ $(document).ready(function () {
 
         api(GARGOYLE.delCondition, data, function (swtch) {
             var result = $("#switchData").tmpl(swtch);
-            $("table.switches tr[data-switch-key="+ data.key + "]").replaceWith(result);
+            $("table.switches tr[data-switch-key='"+ data.key + "']").replaceWith(result);
         });
 
     });
@@ -208,7 +208,7 @@ $(document).ready(function () {
 
                     $.facebox.close();
                 } else {
-                    $("table.switches tr[data-switch-key=" + curkey + "]").replaceWith(result);
+                    $("table.switches tr[data-switch-key='" + curkey + "']").replaceWith(result);
                     $.facebox.close();
                 }
                 result.click();

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(
     zip_safe=False,
     install_requires=[
         'django-modeldict-yplan>=1.5.0',
-        'nexus-yplan>=1.1.0',
+        'nexus-yplan>=1.2.0',
         'django-jsonfield>=0.9.2,!=0.9.13',
     ],
     license='Apache License 2.0',


### PR DESCRIPTION
Merges disqus/gargoyle#73. This fixes the cases with newer jQuery where selector contains dot characters.