### PR TITLE
Fix Nexus admin interface for Switches with spaces in their keys

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -16,6 +16,8 @@ Pending Release
 * Removed all inline javascript.
 * Added ``ifnotswitch`` template tag, a merge of disqus/gargoyle#92, thanks
   @mrfuxi.
+* Fixed Nexus admin interface for Switches with spaces in their keys, an issue
+  reported in disqus/gargoyle#98, thanks @arnaudlimbourg.
 
 1.1.1 (2016-01-15)
 ------------------

--- a/gargoyle/templates/gargoyle/index.html
+++ b/gargoyle/templates/gargoyle/index.html
@@ -44,7 +44,7 @@
 
     <table class="switches {% if not switches %}empty{% endif %}">
         {% for switch in switches %}
-        <tr id="id_{{ switch.key }}" data-switch-key="{{ switch.key }}" data-switch-name="{{ switch.label }}" data-switch-desc="{{ switch.description }}" data-switch-status="{{ switch.status }}">
+        <tr data-switch-key="{{ switch.key }}" data-switch-name="{{ switch.label }}" data-switch-desc="{{ switch.description }}" data-switch-status="{{ switch.status }}">
             <td class="name">
                 <h4>{% if switch.label %}{{ switch.label }}{% else %}{{ switch.key|title }}{% endif %} <small class="command">({{ switch.key }})</small></h4>
                 <h5>
@@ -157,7 +157,7 @@
         </script>
 
         <script type="text/x-jquery-tmpl" id="switchData">
-            <tr id="id_${key}" data-switch-key="${key}" data-switch-name="${label}" data-switch-desc="${description}">
+            <tr data-switch-key="${key}" data-switch-name="${label}" data-switch-desc="${description}">
                 <td class="name">
                     <h4>${label} <small class="command">(${key})</small></h4>
                     <div class="inner">


### PR DESCRIPTION
Fixes the issue reported in disqus/gargoyle#98, thanks @arnaudlimbourg.

Turns out that the rows were being assigned HTML ID's, which are not
allowed to feature spaces, however this is unneccesary since we only use
the `data-` attributes to reference the HTML.