### PR TITLE
Move autodiscovery to AppConfig.ready

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,6 +8,9 @@ Pending Release
 ---------------
 
 * New release notes here
+* Simplified autodiscovery code to use ``AppConfig.ready()``. It's no longer
+  necessary to add a call to ``gargoyle.autodiscover()`` in your ``urls.py``,
+  when not using Nexus.
 
 1.2.0 (2016-02-12)
 ------------------

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -29,20 +29,13 @@ Once you've downloaded the Gargoyle package, you simply need to add it to your `
         'gargoyle',
     )
 
-*If you do not use Nexus*, you will also need to enable discovery of ``gargoyle.py`` modules (which contain
-``ConditionSet``\s). The best place to do this is within your ``urls.py`` file:
+Gargoyle has autodiscovery similar to Django Admin - it will look in each of your ``INSTALLED_APPS`` for a
+``gargoyle`` submodule, and import that. You can use this to declare extra ``ConditionSet``\s. If you use such
+submodules and Python 2.7, you'll need to ensure your imports are not relative in those files:
 
 .. code-block:: python
 
-    import gargoyle
-
-    gargoyle.autodiscover()
-
-If you do use ``gargoyle.py`` files, Python 2.7, and the autodiscovery code, you'll need to ensure your imports are not
-relative:
-
-.. code-block:: python
-
+    # myapp.gargoyle
     from __future__ import absolute_import
 
     from gargoyle.conditions import ConditionSet

--- a/gargoyle/__init__.py
+++ b/gargoyle/__init__.py
@@ -5,12 +5,16 @@ gargoyle
 :copyright: (c) 2010 DISQUS.
 :license: Apache License 2.0, see LICENSE for more details.
 """
+from django.utils.module_loading import autodiscover_modules
+
 from gargoyle.manager import gargoyle
 
 __version__ = '1.2.0'
 VERSION = __version__  # old version compat
 
 __all__ = ('gargoyle', 'autodiscover', '__version__', 'VERSION')
+
+default_app_config = 'gargoyle.apps.GargoyleAppConfig'
 
 
 def autodiscover():
@@ -19,21 +23,4 @@ def autodiscover():
     not present. This forces an import on them to register any gargoyle bits they
     may want.
     """
-    import copy
-    from django.conf import settings
-
-    from importlib import import_module
-
-    for app in settings.INSTALLED_APPS:
-        # Attempt to import the app's gargoyle module.
-        before_import_registry = copy.copy(gargoyle._registry)
-        try:
-            import_module('%s.gargoyle' % app)
-        except:
-            # Reset the model registry to the state before the last import as
-            # this import will have to reoccur on the next request and this
-            # could raise NotRegistered and AlreadyRegistered exceptions
-            gargoyle._registry = before_import_registry
-
-    # load builtins
-    __import__('gargoyle.builtins')
+    autodiscover_modules('gargoyle')

--- a/gargoyle/apps.py
+++ b/gargoyle/apps.py
@@ -1,0 +1,9 @@
+from django.apps import AppConfig
+
+
+class GargoyleAppConfig(AppConfig):
+    name = 'gargoyle'
+    verbose_name = 'Gargoyle'
+
+    def ready(self):
+        self.module.autodiscover()

--- a/gargoyle/nexus_modules.py
+++ b/gargoyle/nexus_modules.py
@@ -15,14 +15,12 @@ from django.conf.urls import patterns, url
 from django.http import HttpResponse, HttpResponseNotFound
 from django.utils import six
 
-from gargoyle import autodiscover, gargoyle, signals
+from gargoyle import gargoyle, signals
 from gargoyle.conditions import ValidationError
 from gargoyle.helpers import dumps
 from gargoyle.models import DISABLED, Switch
 
 GARGOYLE_ROOT = os.path.dirname(__file__)
-
-autodiscover()
 
 logger = logging.getLogger('gargoyle.switches')
 


### PR DESCRIPTION
Fixes #10. Makes installation simpler and autodiscovery more predictable.