### PR TITLE
Fix autodiscovery

### DIFF
--- a/gargoyle/__init__.py
+++ b/gargoyle/__init__.py
@@ -23,4 +23,5 @@ def autodiscover():
     not present. This forces an import on them to register any gargoyle bits they
     may want.
     """
+    import gargoyle.builtins  # noqa
     autodiscover_modules('gargoyle')


### PR DESCRIPTION
523c25807d6e4b2d356580e515258d67a0794d95 broke autodiscovery for applications
that do not import `gargoyle.builtins` anywhere themselves, as it removed the
line that imported them.