### PR TITLE
Fix Django compatibility

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -11,6 +11,7 @@ Pending Release
 * Simplified autodiscovery code to use ``AppConfig.ready()``. It's no longer
   necessary to add a call to ``gargoyle.autodiscover()`` in your ``urls.py``,
   when not using Nexus.
+* Fixed url `patterns` warnings that appear on Django 1.9
 
 1.2.0 (2016-02-12)
 ------------------

--- a/gargoyle/nexus_modules.py
+++ b/gargoyle/nexus_modules.py
@@ -10,7 +10,7 @@ from functools import wraps
 
 import nexus
 from django.conf import settings
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 from django.http import HttpResponse, HttpResponseNotFound
 from django.utils import six
 
@@ -73,8 +73,7 @@ class GargoyleModule(nexus.NexusModule):
         return 'Gargoyle'
 
     def get_urls(self):
-        urlpatterns = patterns(
-            '',
+        return [
             url(r'^add/$', self.as_view(self.add), name='add'),
             url(r'^update/$', self.as_view(self.update), name='update'),
             url(r'^delete/$', self.as_view(self.delete), name='delete'),
@@ -82,9 +81,7 @@ class GargoyleModule(nexus.NexusModule):
             url(r'^conditions/add/$', self.as_view(self.add_condition), name='add-condition'),
             url(r'^conditions/remove/$', self.as_view(self.remove_condition), name='remove-condition'),
             url(r'^$', self.as_view(self.index), name='index'),
-        )
-
-        return urlpatterns
+        ]
 
     def render_on_dashboard(self, request):
         active_switches_count = Switch.objects.exclude(status=DISABLED).count()

--- a/tests/settings/base.py
+++ b/tests/settings/base.py
@@ -4,7 +4,6 @@ import os
 BASE_DIR = os.path.dirname(os.path.dirname(__file__))
 
 DEBUG = True
-TEMPLATE_DEBUG = DEBUG
 
 SECRET_KEY = 'NOTASECRET'
 
@@ -55,6 +54,7 @@ TEMPLATES = [
         'DIRS': [],
         'APP_DIRS': True,
         'OPTIONS': {
+            'debug': True,
             'context_processors': [
                 'django.template.context_processors.debug',
                 'django.template.context_processors.request',

--- a/tests/settings/test.py
+++ b/tests/settings/test.py
@@ -9,3 +9,7 @@ DEBUG = False
 
 DATABASES = deepcopy(DATABASES)
 del DATABASES['default']['NAME']
+
+
+TEMPLATES = deepcopy(TEMPLATES)
+TEMPLATES[0]['OPTIONS']['debug'] = False

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -3,7 +3,7 @@
 :license: Apache License 2.0, see LICENSE for more details.
 """
 import nexus
-from django.conf.urls import include, patterns, url
+from django.conf.urls import include, url
 from django.contrib import admin
 
 from gargoyle.compat import subinclude
@@ -16,9 +16,8 @@ def foo(request):
 admin.autodiscover()
 nexus.autodiscover()
 
-urlpatterns = patterns(
-    '',
+urlpatterns = [
     url(r'^nexus/', include(nexus.site.urls)),
     url(r'^admin/', subinclude(admin.site.urls)),
     url(r'^$', foo, name='gargoyle_test_foo'),
-)
+]


### PR DESCRIPTION
Fixes a couple issues that appear for tests and main code:

* urls `patterns` is deprecated
* `TEMPLATE_DEBUG` no longer exists