### PR TITLE
Fix template tag 'cycle' warning on Django 1.9

### DIFF
--- a/gargoyle/templates/gargoyle/nexus/dashboard.html
+++ b/gargoyle/templates/gargoyle/nexus/dashboard.html
@@ -40,7 +40,7 @@
             <col width="100"/>
         </colgroup>
         {% for switch in switches %}
-            <tr class="{% cycle odd,even %} status-{{ switch.status }}">
+            <tr class="{% cycle 'odd' 'even' %} status-{{ switch.status }}">
                 <td class="status-icon"><span>{{ switch.get_status_display }}</span></td>
                 <th>{% if switch.label %}{{ switch.label }}{% else %}{{ switch.key|title }}{% endif %} <small class="command">({{ switch.key }})</small></th>
                 <td class="status">{{ switch.get_status_display }}</td>


### PR DESCRIPTION
Fixes 'RemovedInDjango110Warning: The old {% cycle %} syntax with comma-separated arguments is deprecated.'.