### PR TITLE
Convert all unittest assert function calls to pytest-style plain assert statements

### DIFF
--- a/tests/testapp/test_api.py
+++ b/tests/testapp/test_api.py
@@ -6,6 +6,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import datetime
 
+import pytest
 from django.contrib.auth.models import AnonymousUser, User
 from django.core.cache import cache
 from django.http import Http404, HttpRequest, HttpResponse
@@ -27,9 +28,9 @@ class APITest(TestCase):
         self.gargoyle.register(IPAddressConditionSet())
 
     def test_builtin_registration(self):
-        self.assertTrue('gargoyle.builtins.UserConditionSet(auth.user)' in self.gargoyle._registry)
-        self.assertTrue('gargoyle.builtins.IPAddressConditionSet' in self.gargoyle._registry)
-        self.assertEquals(len(list(self.gargoyle.get_condition_sets())), 2, self.gargoyle)
+        assert 'gargoyle.builtins.UserConditionSet(auth.user)' in self.gargoyle._registry
+        assert 'gargoyle.builtins.IPAddressConditionSet' in self.gargoyle._registry
+        assert len(list(self.gargoyle.get_condition_sets())) == 2
 
     def test_user(self):
         condition_set = 'gargoyle.builtins.UserConditionSet(auth.user)'
@@ -44,10 +45,10 @@ class APITest(TestCase):
         )
 
         user = User(pk=5)
-        self.assertTrue(self.gargoyle.is_active('test', user))
+        assert self.gargoyle.is_active('test', user)
 
         user = User(pk=8771)
-        self.assertFalse(self.gargoyle.is_active('test', user))
+        assert not self.gargoyle.is_active('test', user)
 
         switch.add_condition(
             condition_set=condition_set,
@@ -56,10 +57,10 @@ class APITest(TestCase):
         )
 
         user = User(pk=8771, is_staff=True)
-        self.assertTrue(self.gargoyle.is_active('test', user))
+        assert self.gargoyle.is_active('test', user)
 
         user = User(pk=8771, is_superuser=True)
-        self.assertFalse(self.gargoyle.is_active('test', user))
+        assert not self.gargoyle.is_active('test', user)
 
         switch.add_condition(
             condition_set=condition_set,
@@ -68,14 +69,14 @@ class APITest(TestCase):
         )
 
         user = User(pk=8771, is_superuser=True)
-        self.assertTrue(self.gargoyle.is_active('test', user))
+        assert self.gargoyle.is_active('test', user)
 
         # test with mock request
-        self.assertTrue(self.gargoyle.is_active('test', self.gargoyle.as_request(user=user)))
+        assert self.gargoyle.is_active('test', self.gargoyle.as_request(user=user))
 
         # test date joined condition
         user = User(pk=8771)
-        self.assertFalse(self.gargoyle.is_active('test', user))
+        assert not self.gargoyle.is_active('test', user)
 
         switch.add_condition(
             condition_set=condition_set,
@@ -84,16 +85,16 @@ class APITest(TestCase):
         )
 
         user = User(pk=8771, date_joined=datetime.datetime(2011, 7, 2))
-        self.assertTrue(self.gargoyle.is_active('test', user))
+        assert self.gargoyle.is_active('test', user)
 
         user = User(pk=8771, date_joined=datetime.datetime(2012, 7, 2))
-        self.assertTrue(self.gargoyle.is_active('test', user))
+        assert self.gargoyle.is_active('test', user)
 
         user = User(pk=8771, date_joined=datetime.datetime(2011, 6, 2))
-        self.assertFalse(self.gargoyle.is_active('test', user))
+        assert not self.gargoyle.is_active('test', user)
 
         user = User(pk=8771, date_joined=datetime.datetime(2011, 7, 1))
-        self.assertTrue(self.gargoyle.is_active('test', user))
+        assert self.gargoyle.is_active('test', user)
 
         switch.clear_conditions(condition_set=condition_set)
         switch.add_condition(
@@ -103,13 +104,13 @@ class APITest(TestCase):
         )
 
         user = User(pk=8771, email="bob@example.com")
-        self.assertTrue(self.gargoyle.is_active('test', user))
+        assert self.gargoyle.is_active('test', user)
 
         user = User(pk=8771, email="bob2@example.com")
-        self.assertFalse(self.gargoyle.is_active('test', user))
+        assert not self.gargoyle.is_active('test', user)
 
         user = User(pk=8771)
-        self.assertFalse(self.gargoyle.is_active('test', user))
+        assert not self.gargoyle.is_active('test', user)
 
     def test_exclusions(self):
         condition_set = 'gargoyle.builtins.UserConditionSet(auth.user)'
@@ -135,16 +136,16 @@ class APITest(TestCase):
         )
 
         user = User(pk=0, username='foo', is_staff=False)
-        self.assertTrue(self.gargoyle.is_active('test', user))
+        assert self.gargoyle.is_active('test', user)
 
         user = User(pk=0, username='foo', is_staff=True)
-        self.assertTrue(self.gargoyle.is_active('test', user))
+        assert self.gargoyle.is_active('test', user)
 
         user = User(pk=0, username='bar', is_staff=False)
-        self.assertFalse(self.gargoyle.is_active('test', user))
+        assert not self.gargoyle.is_active('test', user)
 
         user = User(pk=0, username='bar', is_staff=True)
-        self.assertFalse(self.gargoyle.is_active('test', user))
+        assert not self.gargoyle.is_active('test', user)
 
     def test_only_exclusions(self):
         condition_set = 'gargoyle.builtins.UserConditionSet(auth.user)'
@@ -163,19 +164,19 @@ class APITest(TestCase):
 
         # username=='foo', so should be active
         user = User(pk=0, username='foo', is_staff=False)
-        self.assertTrue(self.gargoyle.is_active('test', user))
+        assert self.gargoyle.is_active('test', user)
 
         # username=='foo', so should be active
         user = User(pk=0, username='foo', is_staff=True)
-        self.assertTrue(self.gargoyle.is_active('test', user))
+        assert self.gargoyle.is_active('test', user)
 
         # username=='bar', so should not be active
         user = User(pk=0, username='bar', is_staff=False)
-        self.assertFalse(self.gargoyle.is_active('test', user))
+        assert not self.gargoyle.is_active('test', user)
 
         # username=='bar', so should not be active
         user = User(pk=0, username='bar', is_staff=True)
-        self.assertFalse(self.gargoyle.is_active('test', user))
+        assert not self.gargoyle.is_active('test', user)
 
     def test_decorator_for_user(self):
         condition_set = 'gargoyle.builtins.UserConditionSet(auth.user)'
@@ -190,12 +191,14 @@ class APITest(TestCase):
         request = HttpRequest()
         request.user = self.user
 
-        self.assertRaises(Http404, test, request)
+        with pytest.raises(Http404):
+            test(request)
 
         switch.status = SELECTIVE
         switch.save()
 
-        self.assertRaises(Http404, test, request)
+        with pytest.raises(Http404):
+            test(request)
 
         switch.add_condition(
             condition_set=condition_set,
@@ -203,7 +206,7 @@ class APITest(TestCase):
             condition='foo',
         )
 
-        self.assertTrue(test(request))
+        assert test(request)
 
     def test_decorator_for_ip_address(self):
         condition_set = 'gargoyle.builtins.IPAddressConditionSet'
@@ -218,7 +221,8 @@ class APITest(TestCase):
         request = HttpRequest()
         request.META['REMOTE_ADDR'] = '192.168.1.1'
 
-        self.assertRaises(Http404, test, request)
+        with pytest.raises(Http404):
+            test(request)
 
         switch.status = SELECTIVE
         switch.save()
@@ -229,7 +233,7 @@ class APITest(TestCase):
             condition='192.168.1.1',
         )
 
-        self.assertTrue(test(request))
+        assert test(request)
 
         # add in a second condition, so that removing the first one won't kick
         # in the "no conditions returns is_active True for selective switches"
@@ -245,7 +249,8 @@ class APITest(TestCase):
             condition='192.168.1.1',
         )
 
-        self.assertRaises(Http404, test, request)
+        with pytest.raises(Http404):
+            test(request)
 
         switch.add_condition(
             condition_set=condition_set,
@@ -253,7 +258,7 @@ class APITest(TestCase):
             condition='192.168.1.1',
         )
 
-        self.assertTrue(test(request))
+        assert test(request)
 
         switch.clear_conditions(
             condition_set=condition_set,
@@ -266,7 +271,7 @@ class APITest(TestCase):
             condition='50-100',
         )
 
-        self.assertTrue(test(request))
+        assert test(request)
 
         switch.clear_conditions(
             condition_set=condition_set,
@@ -278,7 +283,8 @@ class APITest(TestCase):
             condition='0-50',
         )
 
-        self.assertRaises(Http404, test, request)
+        with pytest.raises(Http404):
+            test(request)
 
     def test_decorator_with_redirect(self):
         Switch.objects.create(key='test', status=DISABLED)
@@ -291,31 +297,31 @@ class APITest(TestCase):
             return HttpResponse()
 
         response = test(request)
-        self.assertTrue(response.status_code, 302)
-        self.assertTrue('Location' in response)
-        self.assertTrue(response['Location'], '/foo')
+        assert response.status_code, 302
+        assert 'Location' in response
+        assert response['Location'] == '/foo'
 
         @switch_is_active('test', redirect_to='gargoyle_test_foo')
         def test2(request):
             return HttpResponse()
 
         response = test2(request)
-        self.assertTrue(response.status_code, 302)
-        self.assertTrue('Location' in response)
-        self.assertTrue(response['Location'], '')
+        assert response.status_code, 302
+        assert 'Location' in response
+        assert response['Location'] == '/'
 
     def test_global(self):
         switch = Switch.objects.create(key='test', status=DISABLED)
         switch = self.gargoyle['test']
 
-        self.assertFalse(self.gargoyle.is_active('test'))
-        self.assertFalse(self.gargoyle.is_active('test', self.user))
+        assert not self.gargoyle.is_active('test')
+        assert not self.gargoyle.is_active('test', self.user)
 
         switch.status = GLOBAL
         switch.save()
 
-        self.assertTrue(self.gargoyle.is_active('test'))
-        self.assertTrue(self.gargoyle.is_active('test', self.user))
+        assert self.gargoyle.is_active('test')
+        assert self.gargoyle.is_active('test', self.user)
 
     def test_disable(self):
         switch = Switch.objects.create(key='test')
@@ -325,20 +331,20 @@ class APITest(TestCase):
         switch.status = DISABLED
         switch.save()
 
-        self.assertFalse(self.gargoyle.is_active('test'))
+        assert not self.gargoyle.is_active('test')
 
-        self.assertFalse(self.gargoyle.is_active('test', self.user))
+        assert not self.gargoyle.is_active('test', self.user)
 
     def test_deletion(self):
         switch = Switch.objects.create(key='test')
 
         switch = self.gargoyle['test']
 
-        self.assertTrue('test' in self.gargoyle)
+        assert 'test' in self.gargoyle
 
         switch.delete()
 
-        self.assertFalse('test' in self.gargoyle)
+        assert 'test' not in self.gargoyle
 
     def test_expiration(self):
         switch = Switch.objects.create(key='test')
@@ -348,17 +354,17 @@ class APITest(TestCase):
         switch.status = DISABLED
         switch.save()
 
-        self.assertFalse(self.gargoyle.is_active('test'))
+        assert not self.gargoyle.is_active('test')
 
         Switch.objects.filter(key='test').update(value={}, status=GLOBAL)
 
         # cache shouldn't have expired
-        self.assertFalse(self.gargoyle.is_active('test'))
+        assert not self.gargoyle.is_active('test')
 
         cache_key = self.gargoyle.remote_cache_key
         # in memory cache shouldnt have expired
         cache.delete(cache_key)
-        self.assertFalse(self.gargoyle.is_active('test'))
+        assert not self.gargoyle.is_active('test')
         switch.status, switch.value = GLOBAL, {}
         # Ensure post save gets sent
         self.gargoyle._post_save(sender=None, instance=switch, created=False)
@@ -366,7 +372,7 @@ class APITest(TestCase):
         # any request should expire the in memory cache
         self.client.get('/')
 
-        self.assertTrue(self.gargoyle.is_active('test'))
+        assert self.gargoyle.is_active('test')
 
     def test_anonymous_user(self):
         condition_set = 'gargoyle.builtins.UserConditionSet(auth.user)'
@@ -380,7 +386,7 @@ class APITest(TestCase):
 
         user = AnonymousUser()
 
-        self.assertFalse(self.gargoyle.is_active('test', user))
+        assert not self.gargoyle.is_active('test', user)
 
         switch.add_condition(
             condition_set=condition_set,
@@ -388,11 +394,11 @@ class APITest(TestCase):
             condition='1-10',
         )
 
-        self.assertFalse(self.gargoyle.is_active('test', user))
+        assert not self.gargoyle.is_active('test', user)
 
         switch.clear_conditions(condition_set=condition_set)
 
-        self.assertFalse(self.gargoyle.is_active('test', user))
+        assert not self.gargoyle.is_active('test', user)
 
         switch.add_condition(
             condition_set=condition_set,
@@ -400,7 +406,7 @@ class APITest(TestCase):
             condition='1',
         )
 
-        self.assertTrue(self.gargoyle.is_active('test', user))
+        assert self.gargoyle.is_active('test', user)
 
         switch.add_condition(
             condition_set=condition_set,
@@ -408,7 +414,7 @@ class APITest(TestCase):
             condition='1-10',
         )
 
-        self.assertTrue(self.gargoyle.is_active('test', user))
+        assert self.gargoyle.is_active('test', user)
 
     def test_ip_address_internal_ips(self):
         condition_set = 'gargoyle.builtins.IPAddressConditionSet'
@@ -419,7 +425,7 @@ class APITest(TestCase):
         request = HttpRequest()
         request.META['REMOTE_ADDR'] = '192.168.1.1'
 
-        self.assertFalse(self.gargoyle.is_active('test', request))
+        assert not self.gargoyle.is_active('test', request)
 
         switch.add_condition(
             condition_set=condition_set,
@@ -428,9 +434,9 @@ class APITest(TestCase):
         )
 
         with override_settings(INTERNAL_IPS=['192.168.1.1']):
-            self.assertTrue(self.gargoyle.is_active('test', request))
+            assert self.gargoyle.is_active('test', request)
 
-        self.assertFalse(self.gargoyle.is_active('test', request))
+        assert not self.gargoyle.is_active('test', request)
 
     def test_ip_address(self):
         condition_set = 'gargoyle.builtins.IPAddressConditionSet'
@@ -441,7 +447,7 @@ class APITest(TestCase):
         request = HttpRequest()
         request.META['REMOTE_ADDR'] = '192.168.1.1'
 
-        self.assertFalse(self.gargoyle.is_active('test', request))
+        assert not self.gargoyle.is_active('test', request)
 
         switch.add_condition(
             condition_set=condition_set,
@@ -449,7 +455,7 @@ class APITest(TestCase):
             condition='192.168.1.1',
         )
 
-        self.assertTrue(self.gargoyle.is_active('test', request))
+        assert self.gargoyle.is_active('test', request)
 
         switch.clear_conditions(condition_set=condition_set)
         switch.add_condition(
@@ -458,11 +464,11 @@ class APITest(TestCase):
             condition='127.0.0.1',
         )
 
-        self.assertFalse(self.gargoyle.is_active('test', request))
+        assert not self.gargoyle.is_active('test', request)
 
         switch.clear_conditions(condition_set=condition_set)
 
-        self.assertFalse(self.gargoyle.is_active('test', request))
+        assert not self.gargoyle.is_active('test', request)
 
         switch.add_condition(
             condition_set=condition_set,
@@ -470,10 +476,10 @@ class APITest(TestCase):
             condition='50-100',
         )
 
-        self.assertTrue(self.gargoyle.is_active('test', request))
+        assert self.gargoyle.is_active('test', request)
 
         # test with mock request
-        self.assertTrue(self.gargoyle.is_active('test', self.gargoyle.as_request(ip_address='192.168.1.1')))
+        assert self.gargoyle.is_active('test', self.gargoyle.as_request(ip_address='192.168.1.1'))
 
         switch.clear_conditions(condition_set=condition_set)
         switch.add_condition(
@@ -481,9 +487,9 @@ class APITest(TestCase):
             field_name='percent',
             condition='0-50',
         )
-        self.assertFalse(self.gargoyle.is_active('test', request))
+        assert not self.gargoyle.is_active('test', request)
 
-        self.assertTrue(self.gargoyle.is_active('test', self.gargoyle.as_request(ip_address='::1')))
+        assert self.gargoyle.is_active('test', self.gargoyle.as_request(ip_address='::1'))
 
         switch.clear_conditions(condition_set=condition_set)
         switch.add_condition(
@@ -491,7 +497,7 @@ class APITest(TestCase):
             field_name='percent',
             condition='0-50',
         )
-        self.assertFalse(self.gargoyle.is_active('test', request))
+        assert not self.gargoyle.is_active('test', request)
 
     def test_to_dict(self):
         condition_set = 'gargoyle.builtins.IPAddressConditionSet'
@@ -512,35 +518,23 @@ class APITest(TestCase):
 
         result = switch.to_dict(self.gargoyle)
 
-        self.assertTrue('label' in result)
-        self.assertEquals(result['label'], 'my switch')
-
-        self.assertTrue('status' in result)
-        self.assertEquals(result['status'], SELECTIVE)
-
-        self.assertTrue('description' in result)
-        self.assertEquals(result['description'], 'foo bar baz')
-
-        self.assertTrue('key' in result)
-        self.assertEquals(result['key'], 'test')
-
-        self.assertTrue('conditions' in result)
-        self.assertEquals(len(result['conditions']), 1)
+        assert result['label'] == 'my switch'
+        assert result['status'] == SELECTIVE
+        assert result['description'] == 'foo bar baz'
+        assert result['key'] == 'test'
+        assert len(result['conditions']) == 1
 
         condition = result['conditions'][0]
-        self.assertTrue('id' in condition)
-        self.assertEquals(condition['id'], condition_set)
-        self.assertTrue('label' in condition)
-        self.assertEquals(condition['label'], 'IP Address')
-        self.assertTrue('conditions' in condition)
-        self.assertEquals(len(condition['conditions']), 1)
+        assert condition['id'] == condition_set
+        assert condition['label'] == 'IP Address'
+        assert len(condition['conditions']) == 1
 
         inner_condition = condition['conditions'][0]
-        self.assertEquals(len(inner_condition), 4)
-        self.assertTrue(inner_condition[0], 'ip_address')
-        self.assertTrue(inner_condition[1], '192.168.1.1')
-        self.assertTrue(inner_condition[2], '192.168.1.1')
-        self.assertFalse(inner_condition[3])
+        assert len(inner_condition) == 4
+        assert inner_condition[0] == 'ip_address'
+        assert inner_condition[1] == '192.168.1.1'
+        assert inner_condition[2] == '192.168.1.1'
+        assert not inner_condition[3]
 
     def test_remove_condition(self):
         condition_set = 'gargoyle.builtins.UserConditionSet(auth.user)'
@@ -554,7 +548,7 @@ class APITest(TestCase):
         user5 = User(pk=5, email='5@example.com')
 
         # inactive if selective with no conditions
-        self.assertFalse(self.gargoyle.is_active('test', user5))
+        assert not self.gargoyle.is_active('test', user5)
 
         user8771 = User(pk=8771, email='8771@example.com', is_superuser=True)
         switch.add_condition(
@@ -562,9 +556,9 @@ class APITest(TestCase):
             field_name='is_superuser',
             condition='1',
         )
-        self.assertTrue(self.gargoyle.is_active('test', user8771))
+        assert self.gargoyle.is_active('test', user8771)
         # No longer is_active for user5 as we have other conditions
-        self.assertFalse(self.gargoyle.is_active('test', user5))
+        assert not self.gargoyle.is_active('test', user5)
 
         switch.remove_condition(
             condition_set=condition_set,
@@ -573,8 +567,8 @@ class APITest(TestCase):
         )
 
         # back to inactive for everyone with no conditions
-        self.assertFalse(self.gargoyle.is_active('test', user5))
-        self.assertFalse(self.gargoyle.is_active('test', user8771))
+        assert not self.gargoyle.is_active('test', user5)
+        assert not self.gargoyle.is_active('test', user8771)
 
     def test_switch_defaults(self):
         """Test that defaults pulled from GARGOYLE_SWITCH_DEFAULTS.
@@ -582,20 +576,16 @@ class APITest(TestCase):
         Requires SwitchManager to use auto_create.
 
         """
-        self.assertTrue(self.gargoyle.is_active('active_by_default'))
-        self.assertFalse(self.gargoyle.is_active('inactive_by_default'))
-        self.assertEquals(
-            self.gargoyle['inactive_by_default'].label,
-            'Default Inactive',
-        )
-        self.assertEquals(
-            self.gargoyle['active_by_default'].label,
-            'Default Active',
-        )
+        assert self.gargoyle.is_active('active_by_default')
+        assert not self.gargoyle.is_active('inactive_by_default')
+
+        assert self.gargoyle['inactive_by_default'].label == 'Default Inactive'
+        assert self.gargoyle['active_by_default'].label == 'Default Active'
+
         active_by_default = self.gargoyle['active_by_default']
         active_by_default.status = DISABLED
         active_by_default.save()
-        self.assertFalse(self.gargoyle.is_active('active_by_default'))
+        assert not self.gargoyle.is_active('active_by_default')
 
     def test_invalid_condition(self):
         condition_set = 'gargoyle.builtins.UserConditionSet(auth.user)'
@@ -609,7 +599,7 @@ class APITest(TestCase):
         user5 = User(pk=5, email='5@example.com')
 
         # inactive if selective with no conditions
-        self.assertFalse(self.gargoyle.is_active('test', user5))
+        assert not self.gargoyle.is_active('test', user5)
 
         user8771 = User(pk=8771, email='8771@example.com', is_superuser=True)
         switch.add_condition(
@@ -617,7 +607,7 @@ class APITest(TestCase):
             field_name='foo',
             condition='1',
         )
-        self.assertFalse(self.gargoyle.is_active('test', user8771))
+        assert not self.gargoyle.is_active('test', user8771)
 
     def test_inheritance(self):
         condition_set = 'gargoyle.builtins.UserConditionSet(auth.user)'
@@ -636,42 +626,42 @@ class APITest(TestCase):
         switch = self.gargoyle['test']
 
         user = User(pk=5)
-        self.assertTrue(self.gargoyle.is_active('test:child', user))
+        assert self.gargoyle.is_active('test:child', user)
 
         user = User(pk=8771)
-        self.assertFalse(self.gargoyle.is_active('test:child', user))
+        assert not self.gargoyle.is_active('test:child', user)
 
         switch = self.gargoyle['test']
         switch.status = DISABLED
 
         user = User(pk=5)
-        self.assertFalse(self.gargoyle.is_active('test:child', user))
+        assert not self.gargoyle.is_active('test:child', user)
 
         user = User(pk=8771)
-        self.assertFalse(self.gargoyle.is_active('test:child', user))
+        assert not self.gargoyle.is_active('test:child', user)
 
         switch = self.gargoyle['test']
         switch.status = GLOBAL
 
         user = User(pk=5)
-        self.assertTrue(self.gargoyle.is_active('test:child', user))
+        assert self.gargoyle.is_active('test:child', user)
 
         user = User(pk=8771)
-        self.assertTrue(self.gargoyle.is_active('test:child', user))
+        assert self.gargoyle.is_active('test:child', user)
 
     def test_parent_override_child_state(self):
         Switch.objects.create(key='test', status=DISABLED)
 
         Switch.objects.create(key='test:child', status=GLOBAL)
 
-        self.assertFalse(self.gargoyle.is_active('test:child'))
+        assert not self.gargoyle.is_active('test:child')
 
     def test_child_state_is_used(self):
         Switch.objects.create(key='test', status=GLOBAL)
 
         Switch.objects.create(key='test:child', status=DISABLED)
 
-        self.assertFalse(self.gargoyle.is_active('test:child'))
+        assert not self.gargoyle.is_active('test:child')
 
     def test_parent_override_child_condition(self):
         condition_set = 'gargoyle.builtins.UserConditionSet(auth.user)'
@@ -689,12 +679,12 @@ class APITest(TestCase):
         Switch.objects.create(key='test:child', status=GLOBAL)
 
         user = User(username='bob')
-        self.assertTrue(self.gargoyle.is_active('test:child', user))
+        assert self.gargoyle.is_active('test:child', user)
 
         user = User(username='joe')
-        self.assertFalse(self.gargoyle.is_active('test:child', user))
+        assert not self.gargoyle.is_active('test:child', user)
 
-        self.assertFalse(self.gargoyle.is_active('test:child'))
+        assert not self.gargoyle.is_active('test:child')
 
     def test_child_condition_differing_than_parent_loses(self):
         condition_set = 'gargoyle.builtins.UserConditionSet(auth.user)'
@@ -720,15 +710,15 @@ class APITest(TestCase):
         )
 
         user = User(username='bob')
-        self.assertFalse(self.gargoyle.is_active('test:child', user))
+        assert not self.gargoyle.is_active('test:child', user)
 
         user = User(username='joe')
-        self.assertFalse(self.gargoyle.is_active('test:child', user))
+        assert not self.gargoyle.is_active('test:child', user)
 
         user = User(username='john')
-        self.assertFalse(self.gargoyle.is_active('test:child', user))
+        assert not self.gargoyle.is_active('test:child', user)
 
-        self.assertFalse(self.gargoyle.is_active('test:child'))
+        assert not self.gargoyle.is_active('test:child')
 
     def test_child_condition_including_parent_wins(self):
         condition_set = 'gargoyle.builtins.UserConditionSet(auth.user)'
@@ -759,12 +749,12 @@ class APITest(TestCase):
         )
 
         user = User(username='bob')
-        self.assertTrue(self.gargoyle.is_active('test:child', user))
+        assert self.gargoyle.is_active('test:child', user)
 
         user = User(username='joe')
-        self.assertFalse(self.gargoyle.is_active('test:child', user))
+        assert not self.gargoyle.is_active('test:child', user)
 
         user = User(username='john')
-        self.assertFalse(self.gargoyle.is_active('test:child', user))
+        assert not self.gargoyle.is_active('test:child', user)
 
-        self.assertFalse(self.gargoyle.is_active('test:child'))
+        assert not self.gargoyle.is_active('test:child')

--- a/tests/testapp/test_builtins.py
+++ b/tests/testapp/test_builtins.py
@@ -102,7 +102,7 @@ class HostConditionSetTest(TestCase):
         )
         switch = self.gargoyle['test']
 
-        self.assertFalse(self.gargoyle.is_active('test'))
+        assert not self.gargoyle.is_active('test')
 
         switch.add_condition(
             condition_set=condition_set,
@@ -110,4 +110,4 @@ class HostConditionSetTest(TestCase):
             condition=socket.gethostname(),
         )
 
-        self.assertTrue(self.gargoyle.is_active('test'))
+        assert self.gargoyle.is_active('test')

--- a/tests/testapp/test_commands.py
+++ b/tests/testapp/test_commands.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+import pytest
 from django.core.management import call_command
 from django.core.management.base import CommandError
 from django.test import TestCase
@@ -23,39 +24,40 @@ class CommandAddSwitchTestCase(TestCase):
         for args in too_few_too_many:
             command = AddSwitchCmd()
 
-            self.assertRaises(CommandError, command.handle, *args)
+            with pytest.raises(CommandError):
+                command.handle(*args)
 
     def test_add_switch_default_status(self):
-        self.assertFalse('switch_default' in self.gargoyle)
+        assert 'switch_default' not in self.gargoyle
 
         call_command('add_switch', 'switch_default')
 
-        self.assertTrue('switch_default' in self.gargoyle)
-        self.assertEqual(GLOBAL, self.gargoyle['switch_default'].status)
+        assert 'switch_default' in self.gargoyle
+        assert GLOBAL == self.gargoyle['switch_default'].status
 
     def test_add_switch_with_status(self):
-        self.assertFalse('switch_disabled' in self.gargoyle)
+        assert 'switch_disabled' not in self.gargoyle
 
         call_command('add_switch', 'switch_disabled', status=DISABLED)
 
-        self.assertTrue('switch_disabled' in self.gargoyle)
-        self.assertEqual(DISABLED, self.gargoyle['switch_disabled'].status)
+        assert 'switch_disabled' in self.gargoyle
+        assert DISABLED == self.gargoyle['switch_disabled'].status
 
     def test_update_switch_status_disabled(self):
         Switch.objects.create(key='test', status=GLOBAL)
-        self.assertEqual(GLOBAL, self.gargoyle['test'].status)
+        assert GLOBAL == self.gargoyle['test'].status
 
         call_command('add_switch', 'test', status=DISABLED)
 
-        self.assertEqual(DISABLED, self.gargoyle['test'].status)
+        assert DISABLED == self.gargoyle['test'].status
 
     def test_update_switch_status_to_default(self):
         Switch.objects.create(key='test', status=DISABLED)
-        self.assertEqual(DISABLED, self.gargoyle['test'].status)
+        assert DISABLED == self.gargoyle['test'].status
 
         call_command('add_switch', 'test')
 
-        self.assertEqual(GLOBAL, self.gargoyle['test'].status)
+        assert GLOBAL == self.gargoyle['test'].status
 
 
 class CommandRemoveSwitchTestCase(TestCase):
@@ -71,19 +73,20 @@ class CommandRemoveSwitchTestCase(TestCase):
         for args in too_few_too_many:
             command = RemoveSwitchCmd()
 
-            self.assertRaises(CommandError, command.handle, *args)
+            with pytest.raises(CommandError):
+                command.handle(*args)
 
     def test_removes_switch(self):
         Switch.objects.create(key='test')
-        self.assertTrue('test' in self.gargoyle)
+        assert 'test' in self.gargoyle
 
         call_command('remove_switch', 'test')
 
-        self.assertFalse('test' in self.gargoyle)
+        assert 'test' not in self.gargoyle
 
     def test_remove_non_switch_doesnt_error(self):
-        self.assertFalse('idontexist' in self.gargoyle)
+        assert 'idontexist' not in self.gargoyle
 
         call_command('remove_switch', 'idontexist')
 
-        self.assertFalse('idontexist' in self.gargoyle)
+        assert 'idontexist' not in self.gargoyle

--- a/tests/testapp/test_helpers.py
+++ b/tests/testapp/test_helpers.py
@@ -14,24 +14,24 @@ class MockRequestTest(TestCase):
 
     def test_empty_attrs(self):
         req = MockRequest()
-        self.assertEquals(req.META['REMOTE_ADDR'], None)
-        self.assertEquals(req.user.__class__, AnonymousUser)
+        assert req.META['REMOTE_ADDR'] is None
+        assert isinstance(req.user, AnonymousUser)
 
     def test_ip(self):
         req = MockRequest(ip_address='127.0.0.1')
-        self.assertEquals(req.META['REMOTE_ADDR'], '127.0.0.1')
-        self.assertEquals(req.user.__class__, AnonymousUser)
+        assert req.META['REMOTE_ADDR'] == '127.0.0.1'
+        assert isinstance(req.user, AnonymousUser)
 
     def test_user(self):
         user = User.objects.create(username='foo', email='foo@example.com')
         req = MockRequest(user=user)
-        self.assertEquals(req.META['REMOTE_ADDR'], None)
-        self.assertEquals(req.user, user)
+        assert req.META['REMOTE_ADDR'] is None
+        assert req.user == user
 
     def test_as_request(self):
         user = User.objects.create(username='foo', email='foo@example.com')
 
         req = self.gargoyle.as_request(user=user, ip_address='127.0.0.1')
 
-        self.assertEquals(req.META['REMOTE_ADDR'], '127.0.0.1')
-        self.assertEquals(req.user, user)
+        assert req.META['REMOTE_ADDR'] == '127.0.0.1'
+        assert req.user == user

--- a/tests/testapp/test_manager.py
+++ b/tests/testapp/test_manager.py
@@ -11,21 +11,16 @@ class ConstantTest(TestCase):
         self.gargoyle = SwitchManager(Switch, key='key', value='value', instances=True)
 
     def test_disabled(self):
-        self.assertTrue(hasattr(self.gargoyle, 'DISABLED'))
-        self.assertEquals(self.gargoyle.DISABLED, 1)
+        assert self.gargoyle.DISABLED == 1
 
     def test_selective(self):
-        self.assertTrue(hasattr(self.gargoyle, 'SELECTIVE'))
-        self.assertEquals(self.gargoyle.SELECTIVE, 2)
+        assert self.gargoyle.SELECTIVE == 2
 
     def test_global(self):
-        self.assertTrue(hasattr(self.gargoyle, 'GLOBAL'))
-        self.assertEquals(self.gargoyle.GLOBAL, 3)
+        assert self.gargoyle.GLOBAL == 3
 
     def test_include(self):
-        self.assertTrue(hasattr(self.gargoyle, 'INCLUDE'))
-        self.assertEquals(self.gargoyle.INCLUDE, 'i')
+        assert self.gargoyle.INCLUDE == 'i'
 
     def test_exclude(self):
-        self.assertTrue(hasattr(self.gargoyle, 'EXCLUDE'))
-        self.assertEquals(self.gargoyle.EXCLUDE, 'e')
+        assert self.gargoyle.EXCLUDE == 'e'

--- a/tests/testapp/test_template_tags.py
+++ b/tests/testapp/test_template_tags.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+import pytest
 from django.contrib.auth.models import User
 from django.http import HttpRequest
 from django.template import Context, Template, TemplateSyntaxError
@@ -31,7 +32,7 @@ class IfSwitchTests(BaseTemplateTagTests):
         """)
         rendered = template.render(Context())
 
-        self.assertTrue('hello world!' in rendered)
+        assert 'hello world!' in rendered
 
     def test_else(self):
         Switch.objects.create(key='test', status=DISABLED)
@@ -46,8 +47,8 @@ class IfSwitchTests(BaseTemplateTagTests):
         """)
         rendered = template.render(Context())
 
-        self.assertTrue('foo bar baz' in rendered)
-        self.assertFalse('hello world!' in rendered)
+        assert 'foo bar baz' in rendered
+        assert 'hello world!' not in rendered
 
     def test_with_request(self):
         condition_set = 'gargoyle.builtins.UserConditionSet(auth.user)'
@@ -74,16 +75,17 @@ class IfSwitchTests(BaseTemplateTagTests):
         """)
         rendered = template.render(Context({'request': request}))
 
-        self.assertFalse('foo bar baz' in rendered)
-        self.assertTrue('hello world!' in rendered)
+        assert 'foo bar baz' not in rendered
+        assert 'hello world!' in rendered
 
     def test_missing_name(self):
-        self.assertRaises(TemplateSyntaxError, Template, """
-            {% load gargoyle_tags %}
-            {% ifswitch %}
-            hello world!
-            {% endifswitch %}
-        """)
+        with pytest.raises(TemplateSyntaxError):
+            Template("""
+                {% load gargoyle_tags %}
+                {% ifswitch %}
+                hello world!
+                {% endifswitch %}
+            """)
 
     def test_with_custom_objects(self):
         condition_set = 'gargoyle.builtins.UserConditionSet(auth.user)'
@@ -111,8 +113,8 @@ class IfSwitchTests(BaseTemplateTagTests):
         """)
         rendered = template.render(Context({'request': request}))
 
-        self.assertFalse('foo bar baz' in rendered)
-        self.assertTrue('hello world!' in rendered)
+        assert 'foo bar baz' not in rendered
+        assert 'hello world!' in rendered
 
 
 class IfNotSwitchTests(BaseTemplateTagTests):
@@ -128,7 +130,7 @@ class IfNotSwitchTests(BaseTemplateTagTests):
         """)
         rendered = template.render(Context())
 
-        self.assertFalse('hello world!' in rendered)
+        assert 'hello world!' not in rendered
 
     def test_else(self):
         Switch.objects.create(key='test', status=DISABLED)
@@ -143,8 +145,8 @@ class IfNotSwitchTests(BaseTemplateTagTests):
         """)
         rendered = template.render(Context())
 
-        self.assertFalse('foo bar baz' in rendered)
-        self.assertTrue('hello world!' in rendered)
+        assert 'foo bar baz' not in rendered
+        assert 'hello world!' in rendered
 
     def test_with_request(self):
         condition_set = 'gargoyle.builtins.UserConditionSet(auth.user)'
@@ -171,16 +173,17 @@ class IfNotSwitchTests(BaseTemplateTagTests):
         """)
         rendered = template.render(Context({'request': request}))
 
-        self.assertTrue('foo bar baz' in rendered)
-        self.assertFalse('hello world!' in rendered)
+        assert 'foo bar baz' in rendered
+        assert 'hello world!' not in rendered
 
     def test_missing_name(self):
-        self.assertRaises(TemplateSyntaxError, Template, """
-            {% load gargoyle_tags %}
-            {% ifnotswitch %}
-            hello world!
-            {% endifnotswitch %}
-        """)
+        with pytest.raises(TemplateSyntaxError):
+            Template("""
+                {% load gargoyle_tags %}
+                {% ifnotswitch %}
+                hello world!
+                {% endifnotswitch %}
+            """)
 
     def test_with_custom_objects(self):
         condition_set = 'gargoyle.builtins.UserConditionSet(auth.user)'
@@ -208,5 +211,5 @@ class IfNotSwitchTests(BaseTemplateTagTests):
         """)
         rendered = template.render(Context({'request': request}))
 
-        self.assertTrue('foo bar baz' in rendered)
-        self.assertFalse('hello world!' in rendered)
+        assert 'foo bar baz' in rendered
+        assert 'hello world!' not in rendered

--- a/tests/testapp/test_testutils.py
+++ b/tests/testapp/test_testutils.py
@@ -19,8 +19,8 @@ class SwitchContextManagerTest(TestCase):
         def test():
             return self.gargoyle.is_active('test')
 
-        self.assertTrue(test())
-        self.assertEquals(self.gargoyle['test'].status, DISABLED)
+        assert test()
+        assert self.gargoyle['test'].status == DISABLED
 
         switch.status = GLOBAL
         switch.save()
@@ -29,22 +29,22 @@ class SwitchContextManagerTest(TestCase):
         def test2():
             return self.gargoyle.is_active('test')
 
-        self.assertFalse(test2())
-        self.assertEquals(self.gargoyle['test'].status, GLOBAL)
+        assert not test2()
+        assert self.gargoyle['test'].status == GLOBAL
 
     def test_context_manager(self):
         switch = self.gargoyle['test']
         switch.status = DISABLED
 
         with switches(self.gargoyle, test=True):
-            self.assertTrue(self.gargoyle.is_active('test'))
+            assert self.gargoyle.is_active('test')
 
-        self.assertEquals(self.gargoyle['test'].status, DISABLED)
+        assert self.gargoyle['test'].status == DISABLED
 
         switch.status = GLOBAL
         switch.save()
 
         with switches(self.gargoyle, test=False):
-            self.assertFalse(self.gargoyle.is_active('test'))
+            assert not self.gargoyle.is_active('test')
 
-        self.assertEquals(self.gargoyle['test'].status, GLOBAL)
+        assert self.gargoyle['test'].status == GLOBAL


### PR DESCRIPTION
Makes the tests a lot nicer, plus found a load of un-run asserts! Luckily only one of them was actually wrong.