### PR TITLE
Fix @switches

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,6 +8,8 @@ Pending Release
 ---------------
 
 * New release notes here
+* Bugfix for `@switches` which didn't work on `TestCase` classes properly in
+  1.2.2.
 
 1.2.2 (2016-04-11)
 ------------------

--- a/gargoyle/testutils.py
+++ b/gargoyle/testutils.py
@@ -10,7 +10,6 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import inspect
 import sys
 import unittest
-from functools import wraps
 
 from gargoyle import gargoyle
 from .compat import ContextDecorator
@@ -108,13 +107,6 @@ class SwitchContextManager(TestCaseContextDecorator):
             True: gargoyle.GLOBAL,
             False: gargoyle.DISABLED,
         }
-
-    def __call__(self, func):
-        @wraps(func)
-        def inner(*args, **kwargs):
-            with self:
-                return func(*args, **kwargs)
-        return inner
 
     def __enter__(self):
         self.patch()

--- a/tests/testapp/test_testutils.py
+++ b/tests/testapp/test_testutils.py
@@ -63,7 +63,7 @@ class SwitchContextManagerClassTest(TestCase):
         super(SwitchContextManagerClassTest, self).setUp()
         self.su_switch_value = gargoyle['my_switch_name']
 
-    def test_it(self):
+    def test_it_applied_at_all_levels(self):
         assert self.suc_switch_value
         assert self.su_switch_value
         assert gargoyle['my_switch_name']


### PR DESCRIPTION
It wasn't wrapping properly because it implemented __call__ which overrode the implementation in ContextDecorator.

Properly checked this time that the new test case was collected by pytest.