### PR TITLE
Add migration changing 'choices' for Switch.status from bytes to str

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,6 +8,8 @@ Pending Release
 ---------------
 
 * New release notes here
+* Added a migration to tidy up ``bytes`` versus ``str`` for ``choices`` on
+  ``Switch.status``. It's no-op as ``choices`` is in-memory only.
 
 1.2.3 (2016-04-11)
 ------------------

--- a/gargoyle/migrations/0002_bytes_to_str.py
+++ b/gargoyle/migrations/0002_bytes_to_str.py
@@ -1,0 +1,22 @@
+# -*- coding:utf-8 -*-
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('gargoyle', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='switch',
+            name='status',
+            field=models.PositiveSmallIntegerField(
+                default=1,
+                choices=[(1, 'Disabled'), (2, 'Selective'), (3, 'Global'), (4, 'Inherit')],
+            ),
+        ),
+    ]

--- a/tests/testapp/test_models.py
+++ b/tests/testapp/test_models.py
@@ -1,0 +1,13 @@
+# -*- encoding:utf-8 -*-
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+from django.core.management import call_command
+
+
+def test_no_migrations_required():
+    try:
+        call_command('makemigrations', 'gargoyle', exit=1)
+    except SystemExit:
+        pass
+    else:
+        assert False, "Migrations required"


### PR DESCRIPTION
Fixes #70. This migration is no-op.

Also added a test that ensures that no migrations are required, it fails before this change and passes after.