### PR TITLE
Make gargoyle.register() usable as a decorator, and gargoyle.unregister() return whether it unregistered

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,6 +8,9 @@ Pending Release
 ---------------
 
 * New release notes here
+* Made ``gargoyle.register()`` usable as a decorator
+* Made ``gargoyle.unregister()`` return the boolean value of whether something
+  was unregistered.
 
 1.2.5 (2016-05-09)
 ------------------

--- a/gargoyle/builtins.py
+++ b/gargoyle/builtins.py
@@ -58,6 +58,7 @@ class IPAddress(String):
         return value
 
 
+@gargoyle.register
 class IPAddressConditionSet(RequestConditionSet):
     percent = Percent()
     ip_address = IPAddress(label='IP Address')
@@ -90,9 +91,8 @@ class IPAddressConditionSet(RequestConditionSet):
     def get_group_label(self):
         return 'IP Address'
 
-gargoyle.register(IPAddressConditionSet())
 
-
+@gargoyle.register
 class HostConditionSet(ConditionSet):
     hostname = String()
 
@@ -108,5 +108,3 @@ class HostConditionSet(ConditionSet):
 
     def get_group_label(self):
         return 'Host'
-
-gargoyle.register(HostConditionSet())

--- a/gargoyle/manager.py
+++ b/gargoyle/manager.py
@@ -104,8 +104,11 @@ class SwitchManager(ModelDict):
         """
 
         if callable(condition_set):
-            condition_set = condition_set()
-        self._registry[condition_set.get_id()] = condition_set
+            registerable = condition_set()
+        else:
+            registerable = condition_set
+        self._registry[registerable.get_id()] = registerable
+        return condition_set
 
     def unregister(self, condition_set):
         """
@@ -114,8 +117,11 @@ class SwitchManager(ModelDict):
         >>> gargoyle.unregister(condition_set)
         """
         if callable(condition_set):
-            condition_set = condition_set()
-        self._registry.pop(condition_set.get_id(), None)
+            registerable = condition_set()
+        else:
+            registerable = condition_set
+        popped = self._registry.pop(registerable.get_id(), None)
+        return (popped is not None)
 
     def get_condition_set_by_id(self, switch_id):
         """

--- a/tests/testapp/test_api.py
+++ b/tests/testapp/test_api.py
@@ -30,6 +30,28 @@ class APITest(TestCase):
         self.gargoyle.register(UserConditionSet(User))
         self.gargoyle.register(IPAddressConditionSet())
 
+    def test_register_unregister_class(self):
+        klass = IPAddressConditionSet
+        registered = self.gargoyle.register(IPAddressConditionSet)
+        assert registered is klass
+
+        unregistered = self.gargoyle.unregister(klass)
+        assert unregistered
+
+        unregistered = self.gargoyle.unregister(klass)
+        assert not unregistered
+
+    def test_register_unregister_instance(self):
+        condition_set = IPAddressConditionSet()
+        registered = self.gargoyle.register(condition_set)
+        assert registered is condition_set
+
+        unregistered = self.gargoyle.unregister(condition_set)
+        assert unregistered
+
+        unregistered = self.gargoyle.unregister(condition_set)
+        assert not unregistered
+
     def test_builtin_registration(self):
         assert 'gargoyle.builtins.UserConditionSet(auth.user)' in self.gargoyle._registry
         assert 'gargoyle.builtins.IPAddressConditionSet' in self.gargoyle._registry


### PR DESCRIPTION
Fixes #75.