### PR TITLE
Make 'development mode' easier to use

### DIFF
--- a/tests/testapp/test_api.py
+++ b/tests/testapp/test_api.py
@@ -331,7 +331,7 @@ class APITest(TestCase):
         response = test2(request)
         assert response.status_code, 302
         assert 'Location' in response
-        assert response['Location'] == '/'
+        assert response['Location'] == '/foo/'
 
     def test_global(self):
         switch = Switch.objects.create(key='test', status=DISABLED)

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -7,13 +7,11 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import nexus
 from django.conf.urls import include, url
 from django.contrib import admin
+from django.http import HttpResponse
+from django.views.generic.base import RedirectView
 
 from gargoyle.compat import subinclude
 
-
-def foo(request):
-    from django.http import HttpResponse
-    return HttpResponse()
 
 admin.autodiscover()
 nexus.autodiscover()
@@ -21,5 +19,6 @@ nexus.autodiscover()
 urlpatterns = [
     url(r'^nexus/', include(nexus.site.urls)),
     url(r'^admin/', subinclude(admin.site.urls)),
-    url(r'^$', foo, name='gargoyle_test_foo'),
+    url(r'^foo/$', lambda request: HttpResponse(), name='gargoyle_test_foo'),
+    url(r'^/?$', RedirectView.as_view(url='/nexus/', permanent=False)),
 ]


### PR DESCRIPTION
Redirect from `/` to `/nexus/` so one doesn't need to remember to do that after starting `./manage.py runserver`.