### PR TITLE
Fixed removing conditions in the UI where the value is the empty string

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -11,6 +11,7 @@ Pending Release
 * Made ``gargoyle.register()`` usable as a decorator
 * Made ``gargoyle.unregister()`` return the boolean value of whether something
   was unregistered.
+* Fixed removing conditions where the value is the empty string.
 
 1.2.5 (2016-05-09)
 ------------------

--- a/gargoyle/nexus_modules.py
+++ b/gargoyle/nexus_modules.py
@@ -276,7 +276,7 @@ class GargoyleModule(nexus.NexusModule):
         field_name = request.POST.get("field")
         value = request.POST.get("value")
 
-        if not all([key, condition_set_id, field_name, value]):
+        if not all([key, condition_set_id, field_name]):
             raise GargoyleException("Fields cannot be empty")
 
         switch = gargoyle[key]

--- a/tests/testapp/test_api.py
+++ b/tests/testapp/test_api.py
@@ -590,6 +590,23 @@ class APITest(TestCase):
         assert not self.gargoyle.is_active('test', user5)
         assert not self.gargoyle.is_active('test', user8771)
 
+    def test_add_condition_empty(self):
+        condition_set = 'gargoyle.builtins.UserConditionSet(auth.user)'
+
+        switch = Switch.objects.create(key='test', status=SELECTIVE)
+        switch = self.gargoyle['test']
+
+        user_empty = User(email='')
+        user_non_empty = User(email='test@example.com')
+        switch.add_condition(
+            condition_set=condition_set,
+            field_name='email',
+            condition='',
+        )
+
+        assert self.gargoyle.is_active('test', user_empty)
+        assert not self.gargoyle.is_active('test', user_non_empty)
+
     def test_switch_defaults(self):
         """Test that defaults pulled from GARGOYLE_SWITCH_DEFAULTS.
 


### PR DESCRIPTION
Fixes #55. The API the frontend uses is untested, maybe some tests would have caught it.